### PR TITLE
Development

### DIFF
--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,8 +1,34 @@
-export type PagesUrlsType = {
-  label: string;
+export type APIUrlsType = {
   name: string;
   url: string;
+};
+
+export type PagesUrlsType = APIUrlsType & {
+  label: string;
   isNavigation?: boolean;
+};
+
+export const APIUrls: { [key: string]: APIUrlsType } = {
+  shadow: {
+    name: "shadow",
+    url: "/api/v1/shadow/",
+  },
+  damageMultiplier: {
+    name: "damageMultiplier",
+    url: "/api/v1/shadow/damage_multiplier",
+  },
+  arcanas: {
+    name: "damageMultiplier",
+    url: "/api/v1/shadow/arcanas",
+  },
+  floor: {
+    name: "floor",
+    url: "/api/v1/floor/",
+  },
+  material: {
+    name: "material",
+    url: "/api/v1/material/",
+  },
 };
 
 export const PagesUrls: { [key: string]: PagesUrlsType } = {

--- a/frontend/src/pages/shadow/shadowForm/MainDetails.tsx
+++ b/frontend/src/pages/shadow/shadowForm/MainDetails.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { Divider, Form, Input, Select } from "antd";
 
+import { APIUrls } from "../../../constants";
 import type { ShadowType } from "../../../reducers/types";
 
 import axios from "axios";
@@ -23,7 +24,7 @@ function MainDetails() {
   const getArcanas = () => {
     if (arcanas.length > 0) return;
     axios
-      .get("/api/v1/shadow/arcanas")
+      .get(APIUrls.arcanas.url)
       .then((response: { data: { result: ArcanaType[] } }) => {
         setArcanas(response.data.result);
       });
@@ -36,7 +37,7 @@ function MainDetails() {
       page_size: 100,
     });
     axios
-      .get(`/api/v1/floor/?q=${p}`)
+      .get(`${APIUrls.floors.url}?q=${p}`)
       .then(
         (response: { data: { result: { id: number }[]; count: number } }) => {
           setFloors((f) => [...f, ...response.data.result.map((f) => f.id)]);

--- a/frontend/src/pages/shadow/shadowForm/MainDetails.tsx
+++ b/frontend/src/pages/shadow/shadowForm/MainDetails.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import type {
   ArcanaType,
   FloorType,
-  ShadowSliceInitialStateType,
   ShadowType,
 } from "../../../reducers/types";
 import { Divider, Form, Input, Select } from "antd";
@@ -12,6 +11,7 @@ import { addFloors, setArcanas } from "../../../reducers/shadowSlice";
 import { useDispatch, useSelector } from "react-redux";
 
 import { APIUrls } from "../../../constants";
+import { RootState } from "../../../store";
 
 import axios from "axios";
 import { encode } from "rison";
@@ -19,12 +19,8 @@ import { encode } from "rison";
 function MainDetails() {
   const dispatch = useDispatch();
 
-  const arcanas = useSelector(
-    (state: { shadow: ShadowSliceInitialStateType }) => state.shadow.arcanas
-  );
-  const floors: FloorType[] = useSelector(
-    (state: { shadow: ShadowSliceInitialStateType }) => state.shadow.floors
-  );
+  const arcanas = useSelector((state: RootState) => state.shadow.arcanas);
+  const floors = useSelector((state: RootState) => state.shadow.floors);
 
   React.useEffect(() => {
     if (arcanas.length > 0) return;

--- a/frontend/src/pages/shadow/shadowForm/MainDetails.tsx
+++ b/frontend/src/pages/shadow/shadowForm/MainDetails.tsx
@@ -51,11 +51,11 @@ function MainDetails() {
     <>
       <Divider style={{ marginTop: "0" }}>Main details</Divider>
 
-      <Form.Item<ShadowType<number>> name="id" hidden>
+      <Form.Item<ShadowType> name="id" hidden>
         <Input />
       </Form.Item>
 
-      <Form.Item<ShadowType<number>>
+      <Form.Item<ShadowType>
         label="Name"
         name="name"
         rules={[{ required: true, message: "Please input name for shadow!" }]}
@@ -63,17 +63,17 @@ function MainDetails() {
         <Input />
       </Form.Item>
 
-      <Form.Item<ShadowType<number>> label="Stats" name="stats">
+      <Form.Item<ShadowType> label="Stats" name="stats">
         <Input />
       </Form.Item>
 
-      <Form.Item<ShadowType<number>> label="Arcana" name="arcana">
+      <Form.Item<ShadowType> label="Arcana" name="arcana">
         <Select
           options={arcanas.map((a) => ({ label: a.name, value: a.id }))}
         />
       </Form.Item>
 
-      <Form.Item<ShadowType<number>> label="Floors" name="floors">
+      <Form.Item<ShadowType> label="Floors" name="floors">
         <Select
           options={floors.map((f) => ({ label: f.id, value: f.id }))}
           onOpenChange={() => getFloors(0)}

--- a/frontend/src/pages/shadow/shadowForm/MainDetails.tsx
+++ b/frontend/src/pages/shadow/shadowForm/MainDetails.tsx
@@ -7,10 +7,11 @@ import type {
   ShadowType,
 } from "../../../reducers/types";
 import { Divider, Form, Input, Select } from "antd";
+
+import { addFloors, setArcanas } from "../../../reducers/shadowSlice";
 import { useDispatch, useSelector } from "react-redux";
 
 import { APIUrls } from "../../../constants";
-import { addFloors, setArcanas } from "../../../reducers/shadowSlice";
 
 import axios from "axios";
 import { encode } from "rison";

--- a/frontend/src/pages/shadow/shadowForm/ShadowForm.tsx
+++ b/frontend/src/pages/shadow/shadowForm/ShadowForm.tsx
@@ -3,6 +3,8 @@ import * as style from "./style.scss";
 
 import { APIUrls, PagesUrls } from "../../../constants";
 import { Button, Card, Flex, Form, Space } from "antd";
+
+import { addShadow, updateShadow } from "../../../reducers/shadowSlice";
 import { useNavigate, useParams } from "react-router";
 
 import MainDetails from "./MainDetails";
@@ -11,7 +13,6 @@ import Weakneses from "./Weakneses";
 
 import axios from "axios";
 import classnames from "classnames/bind";
-import { updateShadow } from "../../../reducers/shadowSlice";
 import { useDispatch } from "react-redux";
 
 const cx = classnames.bind(style);
@@ -45,8 +46,9 @@ function ShadowForm() {
     axios
       .put(`${APIUrls.shadow.url}${id}`, data)
       .then((response: { data: { result: ShadowType } }) => {
-        setCurrentShadow(response.data.result);
-        dispatch(updateShadow(response.data.result));
+        const updated = response.data.result;
+        setCurrentShadow(updated);
+        dispatch(updateShadow({ id: updated.id, name: updated.name }));
       });
   };
 
@@ -54,6 +56,8 @@ function ShadowForm() {
     axios
       .post(APIUrls.shadow.url, data)
       .then((response: { data: { id: number; result: ShadowType } }) => {
+        const newShadow = response.data.result;
+        dispatch(addShadow({ id: response.data.id, name: newShadow.name }));
         navigate(`${PagesUrls.shadow.url}${response.data.id}`);
       });
   };

--- a/frontend/src/pages/shadow/shadowForm/ShadowForm.tsx
+++ b/frontend/src/pages/shadow/shadowForm/ShadowForm.tsx
@@ -5,7 +5,7 @@ import { Button, Card, Flex, Form, Space } from "antd";
 import { useNavigate, useParams } from "react-router";
 
 import MainDetails from "./MainDetails";
-import { PagesUrls } from "../../../constants";
+import { APIUrls, PagesUrls } from "../../../constants";
 import type { ShadowType } from "../../../reducers/types";
 import Weakneses from "./Weakneses";
 
@@ -27,7 +27,7 @@ function ShadowForm() {
 
   const getShadow = () => {
     axios
-      .get(`/api/v1/shadow/${params.shadowId}`)
+      .get(`${APIUrls.shadow.url}${params.shadowId}`)
       .then((response: { data: { result: ShadowType<{ id: number }> } }) => {
         const newFloors = response.data.result.floors.map((f) => f.id);
         setCurrentShadow({ ...response.data.result, floors: newFloors });
@@ -42,7 +42,7 @@ function ShadowForm() {
 
   const putHandler = (data: ShadowType<number>, id: number) => {
     axios
-      .put(`/api/v1/shadow/${id}`, data)
+      .put(`${APIUrls.shadow.url}${id}`, data)
       .then((response: { data: { result: ShadowType<number> } }) => {
         setCurrentShadow(response.data.result);
         dispatch(updateShadow(response.data.result));
@@ -51,7 +51,7 @@ function ShadowForm() {
 
   const postHandler = (data: ShadowType<number>) => {
     axios
-      .post("/api/v1/shadow/", data)
+      .post(APIUrls.shadow.url, data)
       .then(
         (response: { data: { id: number; result: ShadowType<number> } }) => {
           navigate(`${PagesUrls.shadow.url}${response.data.id}`);

--- a/frontend/src/pages/shadow/shadowForm/ShadowForm.tsx
+++ b/frontend/src/pages/shadow/shadowForm/ShadowForm.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import * as style from "./style.scss";
 
+import { APIUrls, PagesUrls } from "../../../constants";
 import { Button, Card, Flex, Form, Space } from "antd";
 import { useNavigate, useParams } from "react-router";
 
 import MainDetails from "./MainDetails";
-import { APIUrls, PagesUrls } from "../../../constants";
 import type { ShadowType } from "../../../reducers/types";
 import Weakneses from "./Weakneses";
 

--- a/frontend/src/pages/shadow/shadowForm/ShadowForm.tsx
+++ b/frontend/src/pages/shadow/shadowForm/ShadowForm.tsx
@@ -20,10 +20,11 @@ function ShadowForm() {
   const params = useParams();
   const navigate = useNavigate();
   const dispatch = useDispatch();
-  const [form] = Form.useForm<ShadowType<number>>();
+  const [form] = Form.useForm<ShadowType>();
 
-  const [currentShadow, setCurrentShadow] =
-    React.useState<ShadowType<number> | null>(null);
+  const [currentShadow, setCurrentShadow] = React.useState<ShadowType | null>(
+    null
+  );
 
   const getShadow = () => {
     axios
@@ -40,26 +41,24 @@ function ShadowForm() {
     }
   }, [params]);
 
-  const putHandler = (data: ShadowType<number>, id: number) => {
+  const putHandler = (data: ShadowType, id: number) => {
     axios
       .put(`${APIUrls.shadow.url}${id}`, data)
-      .then((response: { data: { result: ShadowType<number> } }) => {
+      .then((response: { data: { result: ShadowType } }) => {
         setCurrentShadow(response.data.result);
         dispatch(updateShadow(response.data.result));
       });
   };
 
-  const postHandler = (data: ShadowType<number>) => {
+  const postHandler = (data: ShadowType) => {
     axios
       .post(APIUrls.shadow.url, data)
-      .then(
-        (response: { data: { id: number; result: ShadowType<number> } }) => {
-          navigate(`${PagesUrls.shadow.url}${response.data.id}`);
-        }
-      );
+      .then((response: { data: { id: number; result: ShadowType } }) => {
+        navigate(`${PagesUrls.shadow.url}${response.data.id}`);
+      });
   };
 
-  const onFinish = (values: ShadowType<number>) => {
+  const onFinish = (values: ShadowType) => {
     const id = values.id;
     delete values.id;
     if (!id) {

--- a/frontend/src/pages/shadow/shadowForm/Weakneses.tsx
+++ b/frontend/src/pages/shadow/shadowForm/Weakneses.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { Divider, Form, Select } from "antd";
 
+import { APIUrls } from "../../../constants";
 import type { ShadowType } from "../../../reducers/types";
 
 import axios from "axios";
@@ -12,7 +13,7 @@ function Weakneses() {
   const getDamageModifiers = () => {
     if (damageModifiers.length > 0) return;
     axios
-      .get("/api/v1/shadow/damage_multiplier")
+      .get(APIUrls.damageModifiers.url)
       .then((response: { data: { result: string[] } }) => {
         setDamageModifiers(response.data.result);
       });

--- a/frontend/src/pages/shadow/shadowForm/Weakneses.tsx
+++ b/frontend/src/pages/shadow/shadowForm/Weakneses.tsx
@@ -1,21 +1,31 @@
 import * as React from "react";
 
+import type {
+  ShadowSliceInitialStateType,
+  ShadowType,
+} from "../../../reducers/types";
 import { Divider, Form, Select } from "antd";
+import { useDispatch, useSelector } from "react-redux";
 
 import { APIUrls } from "../../../constants";
-import type { ShadowType } from "../../../reducers/types";
+import { setDamageModifiers } from "../../../reducers/shadowSlice";
 
 import axios from "axios";
 
 function Weakneses() {
-  const [damageModifiers, setDamageModifiers] = React.useState<string[]>([]);
+  const dispatch = useDispatch();
+
+  const damageModifiers = useSelector(
+    (state: { shadow: ShadowSliceInitialStateType }) =>
+      state.shadow.damageModifiers
+  );
 
   const getDamageModifiers = () => {
     if (damageModifiers.length > 0) return;
     axios
-      .get(APIUrls.damageModifiers.url)
+      .get(APIUrls.damageMultiplier.url)
       .then((response: { data: { result: string[] } }) => {
-        setDamageModifiers(response.data.result);
+        dispatch(setDamageModifiers(response.data.result));
       });
   };
 

--- a/frontend/src/pages/shadow/shadowForm/Weakneses.tsx
+++ b/frontend/src/pages/shadow/shadowForm/Weakneses.tsx
@@ -1,13 +1,11 @@
 import * as React from "react";
 
 import { Divider, Form, Select } from "antd";
-import type {
-  ShadowSliceInitialStateType,
-  ShadowType,
-} from "../../../reducers/types";
 import { useDispatch, useSelector } from "react-redux";
 
 import { APIUrls } from "../../../constants";
+import { RootState } from "../../../store";
+import type { ShadowType } from "../../../reducers/types";
 
 import axios from "axios";
 import { setDamageModifiers } from "../../../reducers/shadowSlice";
@@ -16,8 +14,7 @@ function Weakneses() {
   const dispatch = useDispatch();
 
   const damageModifiers = useSelector(
-    (state: { shadow: ShadowSliceInitialStateType }) =>
-      state.shadow.damageModifiers
+    (state: RootState) => state.shadow.damageModifiers
   );
 
   const getDamageModifiers = () => {

--- a/frontend/src/pages/shadow/shadowForm/Weakneses.tsx
+++ b/frontend/src/pages/shadow/shadowForm/Weakneses.tsx
@@ -30,63 +30,63 @@ function Weakneses() {
     <>
       <Divider style={{ marginTop: "0" }}>Weakneses</Divider>
 
-      <Form.Item<ShadowType<number>> label="Slash" name="slash">
+      <Form.Item<ShadowType> label="Slash" name="slash">
         <Select
           options={damageModifiers.map((dm) => ({ label: dm, value: dm }))}
           onOpenChange={getDamageModifiers}
         />
       </Form.Item>
 
-      <Form.Item<ShadowType<number>> label="Strike" name="strike">
+      <Form.Item<ShadowType> label="Strike" name="strike">
         <Select
           options={damageModifiers.map((dm) => ({ label: dm, value: dm }))}
           onOpenChange={getDamageModifiers}
         />
       </Form.Item>
 
-      <Form.Item<ShadowType<number>> label="Pierce" name="pierce">
+      <Form.Item<ShadowType> label="Pierce" name="pierce">
         <Select
           options={damageModifiers.map((dm) => ({ label: dm, value: dm }))}
           onOpenChange={getDamageModifiers}
         />
       </Form.Item>
 
-      <Form.Item<ShadowType<number>> label="Fire" name="fire">
+      <Form.Item<ShadowType> label="Fire" name="fire">
         <Select
           options={damageModifiers.map((dm) => ({ label: dm, value: dm }))}
           onOpenChange={getDamageModifiers}
         />
       </Form.Item>
 
-      <Form.Item<ShadowType<number>> label="Ice" name="ice">
+      <Form.Item<ShadowType> label="Ice" name="ice">
         <Select
           options={damageModifiers.map((dm) => ({ label: dm, value: dm }))}
           onOpenChange={getDamageModifiers}
         />
       </Form.Item>
 
-      <Form.Item<ShadowType<number>> label="Lightning" name="lightning">
+      <Form.Item<ShadowType> label="Lightning" name="lightning">
         <Select
           options={damageModifiers.map((dm) => ({ label: dm, value: dm }))}
           onOpenChange={getDamageModifiers}
         />
       </Form.Item>
 
-      <Form.Item<ShadowType<number>> label="Wind" name="wind">
+      <Form.Item<ShadowType> label="Wind" name="wind">
         <Select
           options={damageModifiers.map((dm) => ({ label: dm, value: dm }))}
           onOpenChange={getDamageModifiers}
         />
       </Form.Item>
 
-      <Form.Item<ShadowType<number>> label="Light" name="light">
+      <Form.Item<ShadowType> label="Light" name="light">
         <Select
           options={damageModifiers.map((dm) => ({ label: dm, value: dm }))}
           onOpenChange={getDamageModifiers}
         />
       </Form.Item>
 
-      <Form.Item<ShadowType<number>> label="Darkness" name="darkness">
+      <Form.Item<ShadowType> label="Darkness" name="darkness">
         <Select
           options={damageModifiers.map((dm) => ({ label: dm, value: dm }))}
           onOpenChange={getDamageModifiers}

--- a/frontend/src/pages/shadow/shadowForm/Weakneses.tsx
+++ b/frontend/src/pages/shadow/shadowForm/Weakneses.tsx
@@ -1,16 +1,16 @@
 import * as React from "react";
 
+import { Divider, Form, Select } from "antd";
 import type {
   ShadowSliceInitialStateType,
   ShadowType,
 } from "../../../reducers/types";
-import { Divider, Form, Select } from "antd";
 import { useDispatch, useSelector } from "react-redux";
 
 import { APIUrls } from "../../../constants";
-import { setDamageModifiers } from "../../../reducers/shadowSlice";
 
 import axios from "axios";
+import { setDamageModifiers } from "../../../reducers/shadowSlice";
 
 function Weakneses() {
   const dispatch = useDispatch();

--- a/frontend/src/pages/shadow/shadowsList/Body.tsx
+++ b/frontend/src/pages/shadow/shadowsList/Body.tsx
@@ -1,23 +1,18 @@
 import * as React from "react";
 import * as style from "./style.scss";
 
-import { APIUrls, PagesUrls } from "../../../constants";
-import { Flex, Pagination, Table, TableColumnsType } from "antd";
-import { useDispatch, useSelector } from "react-redux";
+import { Flex, Table, TableColumnsType } from "antd";
 import { useNavigate, useSearchParams } from "react-router";
 
-import { RootState } from "../../../store";
-import type { ShadowType } from "../../../reducers/types";
+import { PagesUrls } from "../../../constants";
+import type { ShadowSimpleType } from "../../../reducers/types";
 
-import axios from "axios";
 import classnames from "classnames/bind";
-
-import { encode } from "rison";
-import { setShadows } from "../../../reducers/shadowSlice";
+import { shadowsCaller } from "../../../reducers/callers";
 
 const cx = classnames.bind(style);
 
-const columns: TableColumnsType<ShadowType> = [
+const columns: TableColumnsType<ShadowSimpleType> = [
   {
     title: "ID",
     dataIndex: "id",
@@ -33,67 +28,46 @@ const columns: TableColumnsType<ShadowType> = [
 function Body() {
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
-  const dispatch = useDispatch();
 
-  const shadows: ShadowType[] = useSelector(
-    (state: RootState) => state.shadow.shadows
-  );
-
-  const [total, setTotal] = React.useState<number>(0);
+  const [shadows, fillShadows] = shadowsCaller();
 
   React.useEffect(() => {
-    const nameFilter = searchParams.get("nameFilter") ?? "";
-    const filters =
-      nameFilter === "" ? [] : [{ col: "name", opr: "ct", value: nameFilter }];
-    const page = searchParams.get("page")
-      ? parseInt(searchParams.get("page"))
-      : 1;
-    const pageSize = searchParams.get("pageSize")
-      ? parseInt(searchParams.get("pageSize"))
-      : 10;
-    const p = encode({
-      page: page - 1,
-      page_size: pageSize,
-      filters,
-    });
+    fillShadows();
+  }, []);
 
-    axios
-      .get(`${APIUrls.shadow.url}?q=${p}`)
-      .then((response: { data: { result: ShadowType[]; count: number } }) => {
-        dispatch(setShadows(response.data.result));
-        setTotal(response.data.count);
-      });
-  }, [searchParams]);
+  const shadowForData = () => {
+    const nameFilter = searchParams.get("nameFilter");
+    return shadows
+      .filter(
+        (s) =>
+          !nameFilter || s.name.toLowerCase().includes(nameFilter.toLowerCase())
+      )
+      .map((s) => ({ ...s, key: s.id }));
+  };
 
   return (
     <div className={cx("shadow-list-body-container")}>
       <Flex justify="center" className={cx("row")}>
-        <Table<ShadowType>
+        <Table<ShadowSimpleType>
+          dataSource={shadowForData()}
           style={{ width: "90%" }}
           columns={columns}
-          dataSource={shadows.map((s) => ({ ...s, key: s.id }))}
           size="middle"
-          pagination={false}
+          pagination={{
+            showSizeChanger: false,
+            current: parseInt(searchParams.get("page")) || 1,
+          }}
+          onChange={(pagination) => {
+            setSearchParams((prev) => {
+              prev.set("page", `${pagination.current}`);
+              return prev;
+            });
+          }}
           onRow={(record) => {
             return {
               onClick: () => navigate(`${PagesUrls.shadow.url}${record.id}`),
             };
           }}
-        />
-      </Flex>
-      <Flex justify="end" className={cx("row")}>
-        <Pagination
-          total={total}
-          showSizeChanger={false}
-          current={
-            searchParams.get("page") ? parseInt(searchParams.get("page")) : 1
-          }
-          onChange={(v) =>
-            setSearchParams((prev) => {
-              prev.set("page", v.toString());
-              return prev;
-            })
-          }
         />
       </Flex>
     </div>

--- a/frontend/src/pages/shadow/shadowsList/Body.tsx
+++ b/frontend/src/pages/shadow/shadowsList/Body.tsx
@@ -17,7 +17,7 @@ import { setShadows } from "../../../reducers/shadowSlice";
 
 const cx = classnames.bind(style);
 
-const columns: TableColumnsType<ShadowType<number>> = [
+const columns: TableColumnsType<ShadowType> = [
   {
     title: "ID",
     dataIndex: "id",
@@ -35,7 +35,7 @@ function Body() {
   const navigate = useNavigate();
   const dispatch = useDispatch();
 
-  const shadows: ShadowType<number>[] = useSelector(
+  const shadows: ShadowType[] = useSelector(
     (state: RootState) => state.shadow.shadows
   );
 
@@ -59,20 +59,16 @@ function Body() {
 
     axios
       .get(`${APIUrls.shadow.url}?q=${p}`)
-      .then(
-        (response: {
-          data: { result: ShadowType<number>[]; count: number };
-        }) => {
-          dispatch(setShadows(response.data.result));
-          setTotal(response.data.count);
-        }
-      );
+      .then((response: { data: { result: ShadowType[]; count: number } }) => {
+        dispatch(setShadows(response.data.result));
+        setTotal(response.data.count);
+      });
   }, [searchParams]);
 
   return (
     <div className={cx("shadow-list-body-container")}>
       <Flex justify="center" className={cx("row")}>
-        <Table<ShadowType<number>>
+        <Table<ShadowType>
           style={{ width: "90%" }}
           columns={columns}
           dataSource={shadows.map((s) => ({ ...s, key: s.id }))}

--- a/frontend/src/pages/shadow/shadowsList/Body.tsx
+++ b/frontend/src/pages/shadow/shadowsList/Body.tsx
@@ -60,7 +60,7 @@ function Body() {
     });
 
     axios
-      .get(`${APIUrls.shadow.url}/?q=${p}`)
+      .get(`${APIUrls.shadow.url}?q=${p}`)
       .then(
         (response: {
           data: { result: ShadowType<number>[]; count: number };

--- a/frontend/src/pages/shadow/shadowsList/Body.tsx
+++ b/frontend/src/pages/shadow/shadowsList/Body.tsx
@@ -3,12 +3,11 @@ import * as style from "./style.scss";
 
 import { APIUrls, PagesUrls } from "../../../constants";
 import { Flex, Pagination, Table, TableColumnsType } from "antd";
-import type {
-  ShadowSliceInitialStateType,
-  ShadowType,
-} from "../../../reducers/types";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useSearchParams } from "react-router";
+
+import { RootState } from "../../../store";
+import type { ShadowType } from "../../../reducers/types";
 
 import axios from "axios";
 import classnames from "classnames/bind";
@@ -37,7 +36,7 @@ function Body() {
   const dispatch = useDispatch();
 
   const shadows: ShadowType<number>[] = useSelector(
-    (state: { shadow: ShadowSliceInitialStateType }) => state.shadow.shadows
+    (state: RootState) => state.shadow.shadows
   );
 
   const [total, setTotal] = React.useState<number>(0);

--- a/frontend/src/pages/shadow/shadowsList/Body.tsx
+++ b/frontend/src/pages/shadow/shadowsList/Body.tsx
@@ -9,7 +9,7 @@ import type {
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useSearchParams } from "react-router";
 
-import { PagesUrls } from "../../../constants";
+import { APIUrls, PagesUrls } from "../../../constants";
 
 import axios from "axios";
 import classnames from "classnames/bind";
@@ -60,7 +60,7 @@ function Body() {
     });
 
     axios
-      .get(`/api/v1/shadow/?q=${p}`)
+      .get(`${APIUrls.shadow.url}/?q=${p}`)
       .then(
         (response: {
           data: { result: ShadowType<number>[]; count: number };

--- a/frontend/src/pages/shadow/shadowsList/Body.tsx
+++ b/frontend/src/pages/shadow/shadowsList/Body.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as style from "./style.scss";
 
+import { APIUrls, PagesUrls } from "../../../constants";
 import { Flex, Pagination, Table, TableColumnsType } from "antd";
 import type {
   ShadowSliceInitialStateType,
@@ -8,8 +9,6 @@ import type {
 } from "../../../reducers/types";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useSearchParams } from "react-router";
-
-import { APIUrls, PagesUrls } from "../../../constants";
 
 import axios from "axios";
 import classnames from "classnames/bind";

--- a/frontend/src/pages/shadow/shadowsList/Body.tsx
+++ b/frontend/src/pages/shadow/shadowsList/Body.tsx
@@ -22,6 +22,8 @@ const columns: TableColumnsType<ShadowSimpleType> = [
     title: "Name",
     dataIndex: "name",
     key: "2",
+    defaultSortOrder: "ascend",
+    sorter: (a, b) => a.name.localeCompare(b.name),
   },
 ];
 

--- a/frontend/src/reducers/callers.ts
+++ b/frontend/src/reducers/callers.ts
@@ -1,0 +1,27 @@
+import { useDispatch, useSelector } from "react-redux";
+
+import { APIUrls } from "../constants";
+import { RootState } from "../store";
+import { ShadowSimpleType } from "./types";
+
+import axios from "axios";
+import { setShadows } from "./shadowSlice";
+
+export function shadowsCaller() {
+  const dispatch = useDispatch();
+
+  const shadows = useSelector((state: RootState) => state.shadow.shadows);
+
+  const fillShadows = () => {
+    if (shadows.length > 0) {
+      return;
+    }
+    axios
+      .get(APIUrls.shadowSimple.url)
+      .then((response: { data: { result: ShadowSimpleType[] } }) => {
+        dispatch(setShadows(response.data.result));
+      });
+  };
+
+  return [shadows, fillShadows] as const;
+}

--- a/frontend/src/reducers/shadowSlice.ts
+++ b/frontend/src/reducers/shadowSlice.ts
@@ -1,11 +1,14 @@
-import { createSlice } from "@reduxjs/toolkit";
-import type { PayloadAction } from "@reduxjs/toolkit";
 import type {
   ArcanaType,
   FloorType,
+  ShadowSimpleType,
   ShadowSliceInitialStateType,
   ShadowType,
 } from "./types";
+
+import type { PayloadAction } from "@reduxjs/toolkit";
+
+import { createSlice } from "@reduxjs/toolkit";
 
 const initialState: ShadowSliceInitialStateType = {
   shadows: [],
@@ -25,13 +28,13 @@ export const shadowSlice = createSlice({
     setDamageModifiers: (state, action: PayloadAction<string[]>) => {
       state.damageModifiers = action.payload;
     },
-    setShadow: (state, action: PayloadAction<ShadowType<number> | null>) => {
+    setShadow: (state, action: PayloadAction<ShadowType | null>) => {
       state.shadow = action.payload;
     },
-    setShadows: (state, action: PayloadAction<ShadowType<number>[]>) => {
+    setShadows: (state, action: PayloadAction<ShadowSimpleType[]>) => {
       state.shadows = action.payload;
     },
-    addShadow: (state, action: PayloadAction<ShadowType<number>>) => {
+    addShadow: (state, action: PayloadAction<ShadowSimpleType>) => {
       state.shadows = [...state.shadows, action.payload];
     },
     addFloors: (state, action: PayloadAction<FloorType[]>) => {
@@ -40,7 +43,7 @@ export const shadowSlice = createSlice({
     removeShadow: (state, action: PayloadAction<number>) => {
       state.shadows = state.shadows.filter((s) => s.id !== action.payload);
     },
-    updateShadow: (state, action: PayloadAction<ShadowType<number>>) => {
+    updateShadow: (state, action: PayloadAction<ShadowSimpleType>) => {
       state.shadows = state.shadows.map((s) =>
         s.id === action.payload.id ? action.payload : s
       );

--- a/frontend/src/reducers/shadowSlice.ts
+++ b/frontend/src/reducers/shadowSlice.ts
@@ -1,16 +1,30 @@
 import { createSlice } from "@reduxjs/toolkit";
 import type { PayloadAction } from "@reduxjs/toolkit";
-import type { ShadowSliceInitialStateType, ShadowType } from "./types";
+import type {
+  ArcanaType,
+  FloorType,
+  ShadowSliceInitialStateType,
+  ShadowType,
+} from "./types";
 
 const initialState: ShadowSliceInitialStateType = {
   shadows: [],
   shadow: null,
+  arcanas: [],
+  damageModifiers: [],
+  floors: [],
 };
 
 export const shadowSlice = createSlice({
   name: "counter",
   initialState,
   reducers: {
+    setArcanas: (state, action: PayloadAction<ArcanaType[]>) => {
+      state.arcanas = action.payload;
+    },
+    setDamageModifiers: (state, action: PayloadAction<string[]>) => {
+      state.damageModifiers = action.payload;
+    },
     setShadow: (state, action: PayloadAction<ShadowType<number> | null>) => {
       state.shadow = action.payload;
     },
@@ -19,6 +33,9 @@ export const shadowSlice = createSlice({
     },
     addShadow: (state, action: PayloadAction<ShadowType<number>>) => {
       state.shadows = [...state.shadows, action.payload];
+    },
+    addFloors: (state, action: PayloadAction<FloorType[]>) => {
+      state.floors = [...state.floors, ...action.payload];
     },
     removeShadow: (state, action: PayloadAction<number>) => {
       state.shadows = state.shadows.filter((s) => s.id !== action.payload);
@@ -32,7 +49,15 @@ export const shadowSlice = createSlice({
 });
 
 // Action creators are generated for each case reducer function
-export const { setShadow, setShadows, addShadow, removeShadow, updateShadow } =
-  shadowSlice.actions;
+export const {
+  addFloors,
+  addShadow,
+  removeShadow,
+  setArcanas,
+  setDamageModifiers,
+  setShadow,
+  setShadows,
+  updateShadow,
+} = shadowSlice.actions;
 
 export default shadowSlice.reducer;

--- a/frontend/src/reducers/types.ts
+++ b/frontend/src/reducers/types.ts
@@ -7,6 +7,11 @@ export type ArcanaType = {
   name: string;
 };
 
+export type ShadowSimpleType = {
+  id: number;
+  name: string;
+};
+
 export type ShadowType<F = number> = {
   id?: number;
   name: string;
@@ -25,7 +30,7 @@ export type ShadowType<F = number> = {
 };
 
 export type ShadowSliceInitialStateType = {
-  shadows: ShadowType[];
+  shadows: ShadowSimpleType[];
   shadow: ShadowType | null;
   arcanas: ArcanaType[];
   damageModifiers: string[];

--- a/frontend/src/reducers/types.ts
+++ b/frontend/src/reducers/types.ts
@@ -1,4 +1,13 @@
-export type ShadowType<F> = {
+export type FloorType = {
+  id: number;
+};
+
+export type ArcanaType = {
+  id: number;
+  name: string;
+};
+
+export type ShadowType<F = number> = {
   id?: number;
   name: string;
   stats: string;
@@ -18,4 +27,7 @@ export type ShadowType<F> = {
 export type ShadowSliceInitialStateType = {
   shadows: ShadowType<number>[];
   shadow: ShadowType<number> | null;
+  arcanas: ArcanaType[];
+  damageModifiers: string[];
+  floors: FloorType[];
 };

--- a/frontend/src/reducers/types.ts
+++ b/frontend/src/reducers/types.ts
@@ -25,8 +25,8 @@ export type ShadowType<F = number> = {
 };
 
 export type ShadowSliceInitialStateType = {
-  shadows: ShadowType<number>[];
-  shadow: ShadowType<number> | null;
+  shadows: ShadowType[];
+  shadow: ShadowType | null;
   arcanas: ArcanaType[];
   damageModifiers: string[];
   floors: FloorType[];

--- a/p3Materials/api/shadow.py
+++ b/p3Materials/api/shadow.py
@@ -3,6 +3,7 @@ from typing import TypedDict
 from flask_appbuilder.api import expose, ModelRestApi
 from flask_appbuilder.const import API_RESULT_RES_KEY
 from flask_appbuilder.models.sqla.interface import SQLAInterface
+from marshmallow import fields, Schema
 
 from p3Materials.constants import Arcanas, DamageMultiplier
 from p3Materials.models.shadow import Floor, Shadow
@@ -11,6 +12,11 @@ from p3Materials.models.shadow import Floor, Shadow
 class ArcanasResponse(TypedDict):
     id: int
     name: str
+
+
+class ShadowSimple(Schema):
+    id = fields.Int()
+    name = fields.String()
 
 
 class FloorModelApi(ModelRestApi):
@@ -93,6 +99,11 @@ class ShadowModelApi(ModelRestApi):
         Shadow.light.key,
         Shadow.darkness.key,
     ]
+
+    @expose("/simple", methods=["GET"])
+    def get_simple(self) -> dict[str, list[str]]:
+        shadows = self.datamodel.session.query(Shadow.id, Shadow.name).all()
+        return {API_RESULT_RES_KEY: ShadowSimple().dump(shadows, many=True)}
 
     @expose("/damage_multiplier", methods=["GET"])
     def get_damage_multiplier(self) -> dict[str, list[str]]:

--- a/p3Materials/app.py
+++ b/p3Materials/app.py
@@ -7,7 +7,7 @@ from p3Materials.api import (
     MaterialModelApi,
     ShadowModelApi,
 )
-from p3Materials.views import P3IndexView, ShadowView
+from p3Materials.views import MaterialView, P3IndexView, ShadowView
 
 
 def create_app() -> Flask:
@@ -27,6 +27,7 @@ def create_app() -> Flask:
         appbuilder.add_api(FloorModelApi)
         appbuilder.add_api(MaterialModelApi)
         appbuilder.add_view(ShadowView, "Shadow", category="Shadow")
+        appbuilder.add_view(MaterialView, "Material", category="Material")
         appbuilder.add_permissions(update_perms=True)
         appbuilder.sm.lm.login_view = "AuthDBView.login"
 

--- a/p3Materials/views.py
+++ b/p3Materials/views.py
@@ -14,3 +14,14 @@ class ShadowView(BaseView):
     @expose("/<int:pk>")
     def shadow(self, pk: int | None = None) -> str:
         return self.render_template("index.html", appbuilder=self.appbuilder)
+
+
+class MaterialView(BaseView):
+    default_view = "material_view"
+    route_base = "/material"
+
+    @expose("/")
+    @expose("/create")
+    @expose("/<int:pk>")
+    def material(self, pk: int | None = None) -> str:
+        return self.render_template("index.html", appbuilder=self.appbuilder)


### PR DESCRIPTION
## New
- Add `APIUrls` constant
- Add `MaterialView`
- Add `simple` route to `Shadow API`
- Add `ShadowSimpleType` type
- Add `shadowsCaller`
- Add sorter to `ShadowList` table

## Fixes
- Remove redundant backslash
- Fix imports order

## Changes
- Use `APIUrls` instead of raw urls
- Move `arcanas`, `damageModifiers` and `floors` to reducer
- Use `RootState`
- Use default type for `ShadowType`
- Use `simple` route for `ShadowList`
- Use `updateShadow` and `addShadow` in `ShadowForm`